### PR TITLE
Allow php-http/discovery to run composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "phpstan/extension-installer": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "php-http/discovery": true
         }
     },
     "autoload": {


### PR DESCRIPTION
Fixes #377